### PR TITLE
Support dynamic chunklists with pruned segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ For example, if you only wanted to return the lowest bitrate, sort worstFirst an
 
 This will prepend a domain or path prefix to all URIs.
 
+### useDynamicChunklists(dynamicChunklists: boolean)
+
+This will set whether to use dynamic URIs for renditions, passing along the original rendition URI, the set baseUrl, and any dynamic chunklist properties, as a query string.
+
+### setDynamicChunklistEndpoint(endpoint: string)
+
+This will set the endpoint that will be used for the dynamic chunklists, with any properties being passed to the endpoint via query string. This can be an absolute path, a relative path, or by default, empty, thereby pointing to the same endpoint that the playlist was accessed from.
+
+### setDynamicChunklistProperties(properties: DynamicChunklistProperties)
+
+This will set the properties that the dynamic chunklist should use, such as its prune type and max duration.
+
 ### Chunklist.loadFromString(m3u8: string)
 
 This static constructor method will return a Chunklist instance. Pass in a string of an m3u8 chunklist.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dynamic-hls-proxy
 
-Load a master HLS playlist (m3u8) and dynamically filter or re-sort it
+Load a master HLS playlist (m3u8) and dynamically filter or re-sort it, or load an HLS chunklist and dynamically prune the segments
 
 ## Install and run it
 
@@ -10,6 +10,7 @@ To manually run a simple demo, clone the repository and then:
 npm install
 npm run build
 npm run demo
+npm run chunklist-demo
 ```
 
 To include this in your existing project, install the npm module:
@@ -74,3 +75,29 @@ For example, if you only wanted to return the lowest bitrate, sort worstFirst an
 ### setBaseUrl(baseUrl: string)
 
 This will prepend a domain or path prefix to all URIs.
+
+### Chunklist.loadFromString(m3u8: string)
+
+This static constructor method will return a Chunklist instance. Pass in a string of an m3u8 chunklist.
+
+### Chunklist.loadFromUrl(url: string)
+
+This static constructor method will return a Chunklist instance. Pass in a string of the url for an m3u8 chunklist. It will be called via a GET request and the response body loaded in as a string.
+
+### setMaxDuration(maxDuration?: number)
+
+This sets the max duration of the clipped chunklist, but is only utilized if a prune type other than "noPrune" is set. The argument is optional. The default will be -1 and therefore no pruning will be done.
+
+### setPruneType(pruneType?: ChunklistPruneType)
+
+This sets how the segments will be pruned, if a max duration is set. The argument is optional. The default will not prune.
+
+ - noPrune = Don't prune the segments at all
+ - pruneStart = Prune away (remove) the beginning segments
+ - pruneEnd = Prune away (remove) the ending segments
+ - pruneStartAndEnd = Prune away (remove) the beginning and ending segments equally, leaving only the middle segments
+ - preview = Chops the chunklist segments up in to thirds, and takes enough of each third to stitch together a preview clip
+
+ ### setBaseUrl(baseUrl: string)
+
+This will prepend a domain or path prefix to all segment URIs.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsc",
     "demo": "node dist/demo.js",
+    "chunklist-demo": "node dist/chunklist-demo.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "publish": "./publish.sh"
   },

--- a/src/chunklist-demo.ts
+++ b/src/chunklist-demo.ts
@@ -1,0 +1,11 @@
+import { Chunklist } from ".";
+
+const chunklistUrl: string = 'http://stream-archive-input-test.s3.amazonaws.com/output/14ajhmZDE6Wi9ct9_qHDCWeukB15ssKO/720p_2034k_v4.m3u8';
+
+Chunklist.loadFromUrl(chunklistUrl).then(function (chunklist: Chunklist) {
+    chunklist
+        .setBaseUrl("https://videos.flosports.net/")
+        // .setTypeFilter(PlaylistTypeFilter.VideoAndAudio)
+        // .sortByBandwidth(RenditionSortOrder.nonHdFirst);
+    console.log(chunklist.toString());
+})

--- a/src/chunklist-demo.ts
+++ b/src/chunklist-demo.ts
@@ -1,11 +1,11 @@
-import { Chunklist } from ".";
+import { Chunklist, ChunklistPruneType } from ".";
 
 const chunklistUrl: string = 'http://stream-archive-input-test.s3.amazonaws.com/output/14ajhmZDE6Wi9ct9_qHDCWeukB15ssKO/720p_2034k_v4.m3u8';
 
 Chunklist.loadFromUrl(chunklistUrl).then(function (chunklist: Chunklist) {
     chunklist
         .setBaseUrl("https://videos.flosports.net/")
-        // .setTypeFilter(PlaylistTypeFilter.VideoAndAudio)
-        // .sortByBandwidth(RenditionSortOrder.nonHdFirst);
+        .setPruneType(ChunklistPruneType.preview)
+        .setMaxDuration(18);
     console.log(chunklist.toString());
 })

--- a/src/chunklist.ts
+++ b/src/chunklist.ts
@@ -168,7 +168,7 @@ export class Chunklist {
             }
 
             if (Math.ceil(chunkDuration) < chunkDurationTarget) {
-                if (totalDuration === 0 && chunkDuration === 0) {
+                if (totalDuration > 0 && chunkDuration === 0) {
                     segments.push(segment.cloneWithDiscontinuity(true));
                 } else {
                     segments.push(segment);

--- a/src/chunklist.ts
+++ b/src/chunklist.ts
@@ -4,11 +4,22 @@ import { Segment } from "./segment";
 const request = require('request');
 const HLS = require('hls-parser'); 
 
+export enum ChunklistPruneType {
+    "noPrune",
+    "pruneStart", // removes beginning segments
+    "pruneEnd", // removes ending segments
+    "pruneStartAndEnd", // removes beginning and ending segments equally, leaving a clip of the middle
+    "preview" // stitches together non-continuous segments to create a preview clip
+}
+
 export class Chunklist {
 
     protected m3u8: iMediaPlaylist;
     protected segments: Segment[] = [];
+    protected totalDuration: number = 0;
     protected baseUrl: string = '';
+    protected pruneType: ChunklistPruneType = ChunklistPruneType.noPrune;
+    protected maxDuration: number = -1;
 
     protected constructor(body: string) {
         let m3u8: iGenericPlaylist = HLS.parse(body);
@@ -20,6 +31,7 @@ export class Chunklist {
         this.m3u8.segments.forEach(function (iSegment: iSegment, index: number) {
             let segment: Segment = new Segment(chunklist, iSegment);
             chunklist.segments.push(segment);
+            chunklist.totalDuration += segment.getDuration();
         });
     }
 
@@ -43,6 +55,24 @@ export class Chunklist {
         });
     }
 
+    public setPruneType(pruneType: ChunklistPruneType): Chunklist {
+        this.pruneType = pruneType;
+        return this;
+    }
+
+    public getPruneType(): ChunklistPruneType {
+        return this.pruneType;
+    }
+
+    public setMaxDuration(maxDuration: number): Chunklist {
+        this.maxDuration = maxDuration;
+        return this;
+    }
+
+    public getMaxDuration(): number {
+        return this.maxDuration;
+    }
+
     public setBaseUrl(baseUrl: string): Chunklist {
         this.baseUrl = baseUrl;
         return this;
@@ -58,18 +88,18 @@ export class Chunklist {
         meta += "#EXT-X-VERSION: " + this.m3u8.version + "\n";
 
         let firstMediaSequenceNumber: number = -1;
-        let maxDuration = 0;
+        let highestDuration = 0;
         let segmentLines: string[] = [];
-        this.segments.forEach(function(segment: Segment) {
+        this.getPrunedSegments().forEach(function(segment: Segment) {
             if (firstMediaSequenceNumber === -1) {
                 firstMediaSequenceNumber = segment.getMediaSequenceNumber();
             }
-            if (segment.getDuration() > maxDuration) {
-                maxDuration = segment.getDuration();
+            if (segment.getDuration() > highestDuration) {
+                highestDuration = segment.getDuration();
             }
             segmentLines.push(segment.toString().trim());
         });
-        meta += "#EXT-X-TARGETDURATION:" + Math.ceil(maxDuration).toString() + "\n";
+        meta += "#EXT-X-TARGETDURATION:" + Math.ceil(highestDuration).toString() + "\n";
         meta += "#EXT-X-MEDIA-SEQUENCE:" + firstMediaSequenceNumber.toString() + "\n";
         if (this.m3u8.playlistType) {
             meta += "#EXT-X-PLAYLIST-TYPE:" + this.m3u8.playlistType + "\n";
@@ -77,5 +107,74 @@ export class Chunklist {
         meta += segmentLines.join("\n") + "\n";
 
         return meta + "#EXT-X-ENDLIST";
+    }
+
+    protected getPrunedSegments(): Segment[] {
+        const maxDuration: number = this.maxDuration;
+        let skipStartLength: number = 0;
+
+        if (this.maxDuration < 1 || this.totalDuration <= this.maxDuration) {
+            return this.segments;
+        }
+
+        switch (this.pruneType) {
+            case ChunklistPruneType.noPrune:
+                return this.segments;
+            case ChunklistPruneType.preview:
+                return this.getPreviewSegments();
+            case ChunklistPruneType.pruneStart:
+                skipStartLength = this.totalDuration - this.maxDuration;
+                break;
+            case ChunklistPruneType.pruneStartAndEnd:
+                skipStartLength = (this.totalDuration - this.maxDuration) / 2;
+                break;
+        }
+
+        let segments: Segment[] = [];
+        let totalStartSkipped: number = 0;
+        let totalDuration: number = 0;
+        this.segments.forEach(function(segment: Segment) {
+            if (skipStartLength > totalStartSkipped) {
+                totalStartSkipped += segment.getDuration();
+                return;
+            }
+            if (totalDuration >= maxDuration) {
+                return;
+            }
+            totalDuration += segment.getDuration();
+            segments.push(segment);
+        });
+
+        return segments;
+    }
+
+    protected getPreviewSegments(): Segment[] {
+        const maxDuration = this.maxDuration;
+        const chunkDurationTarget: number = Math.ceil(this.maxDuration / 3);
+        const skippedDurationTarget: number = Math.floor(this.totalDuration / 3);
+
+        let segments: Segment[] = [];
+        let totalDuration: number = 0;
+        let chunkDuration: number = 0;
+        let skippedDuration: number = 0;
+        this.segments.forEach(function(segment: Segment) {
+            if (totalDuration >= maxDuration) {
+                return;
+            }
+
+            if (chunkDuration < chunkDurationTarget) {
+                chunkDuration += segment.getDuration();
+                segments.push(segment);
+            } else if (skippedDuration < skippedDurationTarget) {
+                skippedDuration += segment.getDuration();
+            }
+
+            if (skippedDuration >= skippedDurationTarget) {
+                skippedDuration = 0;
+                chunkDuration = 0;
+            }
+        });
+
+        return segments;
     }
 }

--- a/src/chunklist.ts
+++ b/src/chunklist.ts
@@ -1,0 +1,81 @@
+import { iMediaPlaylist, iGenericPlaylist, iSegment } from "./hls-parser-types";
+import { Segment } from "./segment";
+
+const request = require('request');
+const HLS = require('hls-parser'); 
+
+export class Chunklist {
+
+    protected m3u8: iMediaPlaylist;
+    protected segments: Segment[] = [];
+    protected baseUrl: string = '';
+
+    protected constructor(body: string) {
+        let m3u8: iGenericPlaylist = HLS.parse(body);
+        let chunklist: Chunklist = this;
+        if (m3u8.isMasterPlaylist) {
+            throw new Error("This m3u8 is a master playlist.");
+        }
+        this.m3u8 = <iMediaPlaylist> m3u8;
+        this.m3u8.segments.forEach(function (iSegment: iSegment, index: number) {
+            let segment: Segment = new Segment(chunklist, iSegment);
+            chunklist.segments.push(segment);
+        });
+    }
+
+    static loadFromString(body: string): Chunklist {
+        return new Chunklist(body);
+    }
+
+    static loadFromUrl(url: string): Promise<Chunklist> {
+        return new Promise(function (resolve, reject) {
+            request(url, function (err, response, body) {
+                if (err) {
+                    reject("Could not load url: " + err);
+                }
+                if (response.statusCode >= 200 && response.statusCode <= 299 && body) {
+                    resolve(new Chunklist(body));
+                }
+                else {
+                    reject("Unexpected http response: " + response.statusCode);
+                }
+            });
+        });
+    }
+
+    public setBaseUrl(baseUrl: string): Chunklist {
+        this.baseUrl = baseUrl;
+        return this;
+    }
+
+    public getBaseUrl(): string {
+        return this.baseUrl;
+    }
+
+    public toString(): string {
+        let chunklist: Chunklist = this;
+        let meta: string = "#EXTM3U\n";
+        meta += "#EXT-X-VERSION: " + this.m3u8.version + "\n";
+
+        let firstMediaSequenceNumber: number = -1;
+        let maxDuration = 0;
+        let segmentLines: string[] = [];
+        this.segments.forEach(function(segment: Segment) {
+            if (firstMediaSequenceNumber === -1) {
+                firstMediaSequenceNumber = segment.getMediaSequenceNumber();
+            }
+            if (segment.getDuration() > maxDuration) {
+                maxDuration = segment.getDuration();
+            }
+            segmentLines.push(segment.toString().trim());
+        });
+        meta += "#EXT-X-TARGETDURATION:" + Math.ceil(maxDuration).toString() + "\n";
+        meta += "#EXT-X-MEDIA-SEQUENCE:" + firstMediaSequenceNumber.toString() + "\n";
+        if (this.m3u8.playlistType) {
+            meta += "#EXT-X-PLAYLIST-TYPE:" + this.m3u8.playlistType + "\n";
+        }
+        meta += segmentLines.join("\n") + "\n";
+
+        return meta + "#EXT-X-ENDLIST";
+    }
+}

--- a/src/chunklist.ts
+++ b/src/chunklist.ts
@@ -150,7 +150,7 @@ export class Chunklist {
 
     protected getPreviewSegments(): Segment[] {
         const maxDuration = this.maxDuration;
-        const chunkDurationTarget: number = Math.ceil(this.maxDuration / 3);
+        const chunkDurationTarget: number = Math.floor(this.maxDuration / 3);
         const skippedDurationTarget: number = Math.floor(this.totalDuration / 3);
 
         let segments: Segment[] = [];
@@ -158,23 +158,24 @@ export class Chunklist {
         let chunkDuration: number = 0;
         let skippedDuration: number = 0;
         this.segments.forEach(function(segment: Segment) {
-            if (totalDuration >= maxDuration) {
+            if (Math.ceil(totalDuration) >= maxDuration) {
                 return;
             }
 
-            if (chunkDuration + skippedDuration >= skippedDurationTarget) {
+            if (Math.ceil(chunkDuration + skippedDuration) >= skippedDurationTarget) {
                 skippedDuration = 0;
                 chunkDuration = 0;
             }
 
-            if (chunkDuration < chunkDurationTarget) {
+            if (Math.ceil(chunkDuration) < chunkDurationTarget) {
                 if (totalDuration === 0 && chunkDuration === 0) {
                     segments.push(segment.cloneWithDiscontinuity(true));
                 } else {
                     segments.push(segment);
                 }
                 chunkDuration += segment.getDuration();
-            } else if (skippedDuration < skippedDurationTarget) {
+                totalDuration += segment.getDuration();
+            } else if (Math.ceil(skippedDuration) < skippedDurationTarget) {
                 skippedDuration += segment.getDuration();
             }
         });

--- a/src/chunklist.ts
+++ b/src/chunklist.ts
@@ -168,8 +168,12 @@ export class Chunklist {
             }
 
             if (chunkDuration < chunkDurationTarget) {
+                if (totalDuration === 0 && chunkDuration === 0) {
+                    segments.push(segment.cloneWithDiscontinuity(true));
+                } else {
+                    segments.push(segment);
+                }
                 chunkDuration += segment.getDuration();
-                segments.push(segment);
             } else if (skippedDuration < skippedDurationTarget) {
                 skippedDuration += segment.getDuration();
             }

--- a/src/chunklist.ts
+++ b/src/chunklist.ts
@@ -162,16 +162,16 @@ export class Chunklist {
                 return;
             }
 
+            if (chunkDuration + skippedDuration >= skippedDurationTarget) {
+                skippedDuration = 0;
+                chunkDuration = 0;
+            }
+
             if (chunkDuration < chunkDurationTarget) {
                 chunkDuration += segment.getDuration();
                 segments.push(segment);
             } else if (skippedDuration < skippedDurationTarget) {
                 skippedDuration += segment.getDuration();
-            }
-
-            if (skippedDuration >= skippedDurationTarget) {
-                skippedDuration = 0;
-                chunkDuration = 0;
             }
         });
 

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -1,4 +1,4 @@
-import { Playlist, PlaylistTypeFilter, RenditionSortOrder } from ".";
+import { Playlist, PlaylistTypeFilter, RenditionSortOrder, ChunklistPruneType } from ".";
 
 const playlistUrl: string = 'http://stream-archive-input-test.s3.amazonaws.com/output/14ajhmZDE6Wi9ct9_qHDCWeukB15ssKO/playlist.m3u8';
 
@@ -6,6 +6,12 @@ Playlist.loadFromUrl(playlistUrl).then(function (playlist: Playlist) {
     playlist
         .setBaseUrl("https://videos.flosports.net/")
         .setTypeFilter(PlaylistTypeFilter.VideoAndAudio)
-        .sortByBandwidth(RenditionSortOrder.nonHdFirst);
+        .sortByBandwidth(RenditionSortOrder.nonHdFirst)
+        .useDynamicChunklists(true)
+        .setDynamicChunklistEndpoint('./chunklist')
+        .setDynamicChunklistProperties({
+            pruneType: ChunklistPruneType.preview,
+            maxDuration: 18,
+        });
     console.log(playlist.toString());
 })

--- a/src/hls-parser-types.ts
+++ b/src/hls-parser-types.ts
@@ -21,17 +21,17 @@ export interface iResolution {
 
 export interface iSegment {
     type: string,
-    url: string,
+    uri: string,
     mimeType: string,
     duration: number,
     title: string,
     byterange: any,
-    discontinuity: string,
+    discontinuity: boolean,
     mediaSequenceNumber: number,
     discontinuitySequence: number,
     key: string,
     map: string,
-    programDateTime: string,
+    programDateTime: Date,
     dateRange: string
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,11 @@
 import { Playlist, PlaylistTypeFilter, RenditionSortOrder } from './playlist';
-import { Chunklist } from './chunklist';
+import { Chunklist, ChunklistPruneType } from './chunklist';
 
 
 export {
     Playlist,
     PlaylistTypeFilter,
     RenditionSortOrder,
-    Chunklist
+    Chunklist,
+    ChunklistPruneType
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Playlist, PlaylistTypeFilter, RenditionSortOrder } from './playlist';
+import { Playlist, PlaylistTypeFilter, RenditionSortOrder, DynamicChunklistProperties } from './playlist';
 import { Chunklist, ChunklistPruneType } from './chunklist';
 
 
@@ -6,6 +6,7 @@ export {
     Playlist,
     PlaylistTypeFilter,
     RenditionSortOrder,
+    DynamicChunklistProperties,
     Chunklist,
     ChunklistPruneType
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,10 @@
 import { Playlist, PlaylistTypeFilter, RenditionSortOrder } from './playlist';
+import { Chunklist } from './chunklist';
 
 
 export {
     Playlist,
     PlaylistTypeFilter,
-    RenditionSortOrder
+    RenditionSortOrder,
+    Chunklist
 };

--- a/src/playlist.ts
+++ b/src/playlist.ts
@@ -1,6 +1,7 @@
 import { iMasterPlaylist, iGenericPlaylist, iVariant, iMediaTrack } from "./hls-parser-types";
 import { Rendition, RenditionType } from "./rendition";
 import { MediaTrack } from "./media-track";
+import { ChunklistPruneType } from "./chunklist";
 
 const request = require('request');
 const HLS = require('hls-parser'); 
@@ -19,6 +20,11 @@ export enum RenditionSortOrder {
     "nonHdFirst"
 }
 
+export interface DynamicChunklistProperties {
+    pruneType: ChunklistPruneType;
+    maxDuration: number;
+}
+
 export class Playlist {
 
     protected m3u8: iMasterPlaylist;
@@ -26,6 +32,12 @@ export class Playlist {
     protected typeFilter: PlaylistTypeFilter = PlaylistTypeFilter.VideoAndAudio;
     protected limit: number = -1;
     protected baseUrl: string = '';
+    protected dynamicChunklists: boolean = false;
+    protected dynamicChunklistEndpoint: string = '';
+    protected dynamicChunklistProperties: DynamicChunklistProperties = {
+        pruneType: ChunklistPruneType.noPrune,
+        maxDuration: -1,
+    };
 
     protected constructor(body: string) {
         let m3u8: iGenericPlaylist = HLS.parse(body);
@@ -139,6 +151,33 @@ export class Playlist {
 
     public getBaseUrl(): string {
         return this.baseUrl;
+    }
+
+    public useDynamicChunklists(dynamicChunklists: boolean): Playlist {
+        this.dynamicChunklists = dynamicChunklists;
+        return this;
+    }
+
+    public hasDynamicChunklists(): boolean {
+        return this.dynamicChunklists;
+    }
+
+    public setDynamicChunklistProperties(properties: DynamicChunklistProperties): Playlist {
+        this.dynamicChunklistProperties = properties;
+        return this;
+    }
+
+    public getDynamicChunklistProperties(): DynamicChunklistProperties {
+        return this.dynamicChunklistProperties;
+    }
+
+    public setDynamicChunklistEndpoint(endpoint: string): Playlist {
+        this.dynamicChunklistEndpoint = endpoint;
+        return this;
+    }
+
+    public getDynamicChunklistEndpoint(): string {
+        return this.dynamicChunklistEndpoint;
     }
 
     public toString(): string {

--- a/src/playlist.ts
+++ b/src/playlist.ts
@@ -31,7 +31,7 @@ export class Playlist {
         let m3u8: iGenericPlaylist = HLS.parse(body);
         let playlist: Playlist = this;
         if (!m3u8.isMasterPlaylist) {
-            new Error("This m3u8 is not a master playlist.");
+            throw new Error("This m3u8 is not a master playlist.");
         }
         this.m3u8 = <iMasterPlaylist> m3u8;
         this.m3u8.variants.forEach(function (variant: iVariant, index: number) {

--- a/src/rendition.ts
+++ b/src/rendition.ts
@@ -3,7 +3,6 @@ import { Playlist, PlaylistTypeFilter } from "./playlist";
 import { StreamInfo } from "./stream-info";
 
 const querystring = require('querystring');
-const extend = require('util')._extend;
 
 export enum RenditionType {
     "video",
@@ -50,7 +49,7 @@ export class Rendition {
             return out;
         }
         if (this.playlist.hasDynamicChunklists()) {
-            const props = extend({}, this.playlist.getDynamicChunklistProperties());
+            const props = JSON.parse(JSON.stringify(this.playlist.getDynamicChunklistProperties()));
             props.uri = this.variant.uri;
             props.baseUrl = this.playlist.getBaseUrl();
 

--- a/src/rendition.ts
+++ b/src/rendition.ts
@@ -2,6 +2,9 @@ import { iVariant } from "./hls-parser-types";
 import { Playlist, PlaylistTypeFilter } from "./playlist";
 import { StreamInfo } from "./stream-info";
 
+const querystring = require('querystring');
+const extend = require('util')._extend;
+
 export enum RenditionType {
     "video",
     "audio",
@@ -43,9 +46,19 @@ export class Rendition {
     public toString(): string {
         let out: string = '';
         out += this.streamInfo.toString();
-        if (!this.variant.isIFrameOnly) {
+        if (this.variant.isIFrameOnly) {
+            return out;
+        }
+        if (this.playlist.hasDynamicChunklists()) {
+            const props = extend({}, this.playlist.getDynamicChunklistProperties());
+            props.uri = this.variant.uri;
+            props.baseUrl = this.playlist.getBaseUrl();
+
+            out += this.playlist.getDynamicChunklistEndpoint() + '?' + querystring.stringify(props) + "\n";
+        } else {
             out += this.playlist.getBaseUrl() + this.variant.uri + "\n";
         }
+
         return out;
     }
 

--- a/src/segment-info.ts
+++ b/src/segment-info.ts
@@ -1,0 +1,49 @@
+import { iSegment } from "./hls-parser-types";
+import { Chunklist } from "./chunklist";
+
+export class SegmentInfo {
+
+    protected segment: iSegment;
+    protected chunklist: Chunklist;
+
+    constructor(chunklist: Chunklist, variant: iSegment) {
+        this.chunklist = chunklist;
+        this.segment = variant;
+    }
+
+    protected propertiesToCommaSeparated(properties: any[]): string {
+        let out: string = '';
+        for (let i: number = 0; i < properties.length; i++) {
+            if (i > 0) {
+                out += ',';
+            }
+            out += properties[i].join('=');
+        }
+        return out;
+    }
+
+    public toString(): string {
+        let out: string = '';
+        let duration: string;
+        let properties: any[] = [];
+
+        if (this.segment.programDateTime) {
+            out += "#EXT-X-PROGRAM-DATE-TIME:" + this.segment.programDateTime.toISOString() + "\n";
+        }
+        if (this.segment.discontinuity) {
+            out += "#EXT-X-DISCONTINUITY\n";
+        }
+        if (this.segment.duration % 1 === 0) {
+            duration = this.segment.duration.toFixed(1);
+        } else {
+            duration = this.segment.duration.toString();
+        }
+        out += "#EXTINF:" + duration + ",\n";
+        if (this.segment.byterange) {
+            out += "#EXT-X-BYTERANGE:" + this.segment.byterange.length + "@" + this.segment.byterange.offset + "\n";
+        }
+
+        return out;
+    }
+
+}

--- a/src/segment.ts
+++ b/src/segment.ts
@@ -1,0 +1,32 @@
+import { iSegment } from "./hls-parser-types";
+import { Chunklist } from "./chunklist";
+import { SegmentInfo } from "./segment-info";
+
+export class Segment {
+
+    protected segment: iSegment;
+    protected segmentInfo: SegmentInfo;
+    protected chunklist: Chunklist;
+
+    constructor(chunklist: Chunklist, segment: iSegment) {
+        this.segment = segment;
+        this.segmentInfo = new SegmentInfo(chunklist, segment);
+        this.chunklist = chunklist;
+    }
+
+    public getMediaSequenceNumber(): number {
+        return this.segment.mediaSequenceNumber;
+    }
+
+    public getDuration(): number {
+        return this.segment.duration;
+    }
+
+    public toString(): string {
+        let out: string = '';
+        out += this.segmentInfo.toString();
+        out += this.chunklist.getBaseUrl() + this.segment.uri + "\n";
+
+        return out;
+    }
+}

--- a/src/segment.ts
+++ b/src/segment.ts
@@ -22,6 +22,13 @@ export class Segment {
         return this.segment.duration;
     }
 
+    public cloneWithDiscontinuity(discontinuity: boolean): Segment {
+        const segment: iSegment = JSON.parse(JSON.stringify(this.segment));
+        segment.discontinuity = discontinuity;
+
+        return new Segment(this.chunklist, segment);
+    }
+
     public toString(): string {
         let out: string = '';
         out += this.segmentInfo.toString();


### PR DESCRIPTION
This will allow the dynamically generated playlists to reference an endpoint that can dynamically generate the chunklists/renditions so that the chunklist can be pruned down in duration, either by pruning the beginning, the end, or both.

A chunklist can also be pruned in to a "preview" which will take segments from 3 different spots within the chunklist in order to form a stitched-together clip/preview of non-continuous segments.