### PR TITLE
Add getVideoRenditionUrl to Playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ This will set the endpoint that will be used for the dynamic chunklists, with an
 
 This will set the properties that the dynamic chunklist should use, such as its prune type and max duration.
 
+### getVideoRenditionUrl(atIndex: number, absolute: boolean)
+
+Returns the video rendition URL at the specified index. This is affected by sortByBandwidth, but NOT by setFilterType. "absolute" defaults to true and returns the fully-qualified URL while false would return the exact path that's written within the original Playlist.
+
 ### Chunklist.loadFromString(m3u8: string)
 
 This static constructor method will return a Chunklist instance. Pass in a string of an m3u8 chunklist.

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -25,4 +25,5 @@ Playlist.loadFromUrl(playlistUrl).then(function (playlist: Playlist) {
         .setTypeFilter(PlaylistTypeFilter.VideoAndAudio)
         .sortByBandwidth(RenditionSortOrder.worstFirst);
     console.log(playlist.toString());
+    console.log(playlist.getVideoRenditionUrl(0));
 })

--- a/src/playlist.ts
+++ b/src/playlist.ts
@@ -108,6 +108,31 @@ export class Playlist {
         this.resolutionRange = [min, max];
     }
 
+    public getVideoRenditionUrl(atIndex: number, absolute: boolean = true) {
+        let videoRenditions: Rendition[] = [];
+
+        this.renditions.forEach(function (rendition: Rendition) {
+            if (rendition.getType() == RenditionType.video) {
+                videoRenditions.push(rendition);
+            }
+        });
+
+        if (!(atIndex in videoRenditions)) {
+            throw new Error(`Video Rendition not found at index ${atIndex}`);
+        }
+
+        const rendition: Rendition = videoRenditions[atIndex];
+
+        if (!absolute) {
+            return rendition.getUri();
+        }
+
+        return Playlist.buildUrl(
+            this.getBaseUrl() + rendition.getUri(),
+            this.getQueryStringParams()
+        );
+    }
+
     public sortByBandwidth(order: RenditionSortOrder = RenditionSortOrder.bestFirst): Playlist {
         const playlist: Playlist = this;
         let middleBandwidth: number | null = null;

--- a/src/rendition.ts
+++ b/src/rendition.ts
@@ -53,6 +53,10 @@ export class Rendition {
         return this.variant.averageBandwidth;
     }
 
+    public getUri(): string {
+        return this.variant.uri;
+    }
+
     public isResolutionBetween(range: [number, number]): boolean {
         const height: number = this.getHeight();
         return typeof height == 'undefined' || (


### PR DESCRIPTION
@jasonbyrne once approved and merged, could you publish a new version?

Hoping to use this as a way to retrieve the highest bandwidth rendition URL (non-absolute) so that I can query S3 for that file's size. This is so I can monitor, within a different project, when we get playlists that contain a 5GB+ rendition.